### PR TITLE
Replace haskell98 with base.

### DIFF
--- a/VM.hs
+++ b/VM.hs
@@ -1,7 +1,7 @@
 module VM where
 
-import Array
-import IO
+import Data.Array
+import System.IO
 import System.Random
 
 {- Stack machine for running whitespace programs -}

--- a/main.hs
+++ b/main.hs
@@ -26,7 +26,7 @@ import Input
 import VM
 import Tokens
 
-import System(getArgs)
+import System.Environment(getArgs)
 
 main :: IO ()
 main = do

--- a/whitespace.cabal
+++ b/whitespace.cabal
@@ -15,4 +15,4 @@ Extra-Source-Files:  VM.hs Tokens.hs Input.hs
 
 Executable wspace
   Main-is:           main.hs
-  Build-Depends:     haskell98, random
+  Build-Depends:     array, base, random


### PR DESCRIPTION
Now `haskell98` package becomes too old and I cannot build this package with Cabal (or, Stack). Please `haskell98` with `base`.